### PR TITLE
Corrected name of function as it is called from ofxstatement/tool.py

### DIFF
--- a/src/ofxstatement/plugins/sample.py
+++ b/src/ofxstatement/plugins/sample.py
@@ -7,7 +7,7 @@ class SamplePlugin(Plugin):
     """Sample plugin (for developers only)
     """
 
-    def getParser(self, filename):
+    def get_parser(self, filename):
         return SampleParser(filename)
 
 


### PR DESCRIPTION
ofxstatement/tool.py calls "p.get_parser" now.
